### PR TITLE
Add Linux and macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ lib/
 *.pdb
 *.ilk
 *.obj
+*.so
+*.so.*
+*.dylib
 
 
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,35 @@
 cmake_minimum_required(VERSION 3.22...3.25)
 project(flood-tuber VERSION 1.1.0)
 
+find_package(libobs CONFIG REQUIRED)
+
+# Platform-agnostic install destinations (fallback if OBS cmake helpers unavailable)
+if(NOT DEFINED OBS_PLUGIN_DESTINATION)
+    if(WIN32)
+        set(OBS_PLUGIN_DESTINATION "obs-plugins/64bit")
+    elseif(APPLE)
+        set(OBS_PLUGIN_DESTINATION "obs-plugins")
+    else()
+        set(OBS_PLUGIN_DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins")
+    endif()
+endif()
+if(NOT DEFINED OBS_DATA_DESTINATION)
+    if(WIN32)
+        set(OBS_DATA_DESTINATION "data/obs-plugins")
+    elseif(APPLE)
+        set(OBS_DATA_DESTINATION "data/obs-plugins")
+    else()
+        set(OBS_DATA_DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins")
+    endif()
+endif()
+
 # 1. Plugin Definition
 add_library(flood-tuber MODULE)
-set_target_properties_obs(flood-tuber PROPERTIES FOLDER plugins PREFIX "")
+set_target_properties(flood-tuber PROPERTIES
+    PREFIX ""
+    FOLDER plugins
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/obs-plugins"
+)
 
 # Version passed to C++ code via compile define (single source of truth)
 target_compile_definitions(flood-tuber PRIVATE
@@ -63,3 +89,12 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/data")
         )
     endforeach()
 endif()
+
+# 6. Install rules
+install(TARGETS flood-tuber
+    LIBRARY DESTINATION "${OBS_PLUGIN_DESTINATION}"
+    RUNTIME DESTINATION "${OBS_PLUGIN_DESTINATION}")
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data/"
+    DESTINATION "${OBS_DATA_DESTINATION}/flood-tuber"
+    USE_SOURCE_PERMISSIONS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT DEFINED OBS_PLUGIN_DESTINATION)
     elseif(APPLE)
         set(OBS_PLUGIN_DESTINATION "obs-plugins")
     else()
-        set(OBS_PLUGIN_DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins")
+        set(OBS_PLUGIN_DESTINATION "${CMAKE_INSTALL_LIBDIR}/obs-plugins")
     endif()
 endif()
 if(NOT DEFINED OBS_DATA_DESTINATION)
@@ -19,17 +19,21 @@ if(NOT DEFINED OBS_DATA_DESTINATION)
     elseif(APPLE)
         set(OBS_DATA_DESTINATION "data/obs-plugins")
     else()
-        set(OBS_DATA_DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins")
+        set(OBS_DATA_DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/obs/obs-plugins")
     endif()
 endif()
 
 # 1. Plugin Definition
 add_library(flood-tuber MODULE)
-set_target_properties(flood-tuber PROPERTIES
-    PREFIX ""
-    FOLDER plugins
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/obs-plugins"
-)
+if(COMMAND set_target_properties_obs)
+    set_target_properties_obs(flood-tuber PROPERTIES FOLDER plugins PREFIX "")
+else()
+    set_target_properties(flood-tuber PROPERTIES
+        PREFIX ""
+        FOLDER plugins
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/obs-plugins"
+    )
+endif()
 
 # Version passed to C++ code via compile define (single source of truth)
 target_compile_definitions(flood-tuber PRIVATE

--- a/README.md
+++ b/README.md
@@ -47,7 +47,35 @@ You can download the latest version of Flood Tuber from:
 2.  Extract the contents.
 3.  Copy the `flood-tuber.dll` into your OBS plugins folder (usually `C:\Program Files\obs-studio\obs-plugins\64bit`).
 4.  Copy the `flood-tuber` folder from the `data/obs-plugins` folder to the OBS data directory (usually `C:\Program Files\obs-studio\data\obs-plugins\flood-tuber`).
-5.  Restart OBS Studio.
+ 5.  Restart OBS Studio.
+
+### macOS
+
+#### Building from source
+
+**Prerequisites:** OBS Studio (Homebrew), CMake, Git, and Xcode Command Line Tools.
+
+```bash
+# Install dependencies
+brew install cmake obs-studio
+```
+
+**Build and install:**
+
+```bash
+git clone https://github.com/justflood/flood-tuber.git
+cd flood-tuber
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+sudo cmake --install build --prefix /usr/local
+```
+
+#### Manual installation (portable)
+
+1. Build as shown above.
+2. Copy `build/flood-tuber.so` to `~/Library/Application Support/obs-studio/plugins/flood-tuber/bin/`
+3. Copy the `data/` directory contents to `~/Library/Application Support/obs-studio/plugins/flood-tuber/data/`
+4. Restart OBS Studio.
 
 ### Linux
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ You can download the latest version of Flood Tuber from:
 *   **[Official OBS Resources Page](https://obsproject.com/forum/resources/flood-tuber-native-pngtuber-plugin.2336/)** 
 *   **[GitHub Releases](https://github.com/justflood/flood-tuber/releases/latest)** (Recommended)
 
-I offer two installation methods:
+### Windows
 
-### Option 1: Installer (Recommended)
+#### Option 1: Installer (Recommended)
 1.  Download the `FloodTuber-Installer.exe`.
 2.  Run the installer.
     > **⚠️ Note regarding "Windows protected your PC":**
@@ -42,12 +42,43 @@ I offer two installation methods:
     > *   Click **"Run Anyway"**
 3.  Follow the setup wizard instructions.
 
-### Option 2: Portable (Manual)
+#### Option 2: Portable (Manual)
 1.  Download the `FloodTuber-Portable.zip`.
 2.  Extract the contents.
 3.  Copy the `flood-tuber.dll` into your OBS plugins folder (usually `C:\Program Files\obs-studio\obs-plugins\64bit`).
 4.  Copy the `flood-tuber` folder from the `data/obs-plugins` folder to the OBS data directory (usually `C:\Program Files\obs-studio\data\obs-plugins\flood-tuber`).
 5.  Restart OBS Studio.
+
+### Linux
+
+#### Building from source
+
+**Prerequisites:** OBS Studio development headers, CMake, Git, and a C++ compiler.
+
+```bash
+# Ubuntu/Debian
+sudo apt install build-essential cmake git libobs-dev
+
+# Fedora
+sudo dnf install cmake git obs-studio-devel
+```
+
+**Build and install:**
+
+```bash
+git clone https://github.com/justflood/flood-tuber.git
+cd flood-tuber
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+sudo cmake --install build --prefix /usr
+```
+
+#### Manual installation (portable)
+
+1. Build as shown above.
+2. Copy `build/flood-tuber.so` to `~/.config/obs-studio/plugins/flood-tuber/bin/64bit/`
+3. Copy the `data/` directory contents to `~/.config/obs-studio/plugins/flood-tuber/data/`
+4. Restart OBS Studio.
 
 ## Usage
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -30,9 +30,9 @@ Flood Tuber'ın en son sürümünü şuradan indirebilirsiniz:
 *   **[Resmi OBS Kaynaklar Sayfası](https://obsproject.com/forum/resources/flood-tuber-native-pngtuber-plugin.2336/)**
 *   **[GitHub Sürümler (Releases)](https://github.com/justflood/flood-tuber/releases/latest)** (Önerilen)
 
-İki kurulum yöntemi vardır:
+### Windows
 
-### Seçenek 1: Yükleyici (Önerilen)
+#### Seçenek 1: Yükleyici (Önerilen)
 1.  `FloodTuber-Installer-x.x.x.exe` dosyasını indirin.
 2.  Yükleyiciyi çalıştırın.
     > **⚠️ "Windows kişisel bilgisayarınızı korudu" uyarısı hakkında not:**
@@ -42,12 +42,43 @@ Flood Tuber'ın en son sürümünü şuradan indirebilirsiniz:
     > *   **"Yine de Çalıştır" (Run Anyway)** butonuna basın.
 3.  Kurulum sihirbazındaki adımları takip edin.
 
-### Seçenek 2: Taşınabilir / Zip (Manuel)
+#### Seçenek 2: Taşınabilir / Zip (Manuel)
 1.  `FloodTuber-Portable-vx.x.x.zip` dosyasını indirin.
 2.  Dosyaları bir klasöre çıkarın.
 3.  `flood-tuber.dll` dosyasını OBS eklenti klasörünüze kopyalayın (genellikle `C:\Program Files\obs-studio\obs-plugins\64bit`).
 4.  `data/obs-plugins` klasörü içindeki `flood-tuber` klasörünü OBS veri dizinine kopyalayın (genellikle `C:\Program Files\obs-studio\data\obs-plugins\flood-tuber`).
 5.  OBS Studio'yu yeniden başlatın.
+
+### Linux
+
+#### Kaynak koddan derleme
+
+**Gereksinimler:** OBS Studio geliştirme başlıkları, CMake, Git ve bir C++ derleyicisi.
+
+```bash
+# Ubuntu/Debian
+sudo apt install build-essential cmake git libobs-dev
+
+# Fedora
+sudo dnf install cmake git obs-studio-devel
+```
+
+**Derleme ve kurulum:**
+
+```bash
+git clone https://github.com/justflood/flood-tuber.git
+cd flood-tuber
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+sudo cmake --install build --prefix /usr
+```
+
+#### Manuel kurulum (taşınabilir)
+
+1. Yukarıdaki gibi derleyin.
+2. `build/flood-tuber.so` dosyasını `~/.config/obs-studio/plugins/flood-tuber/bin/64bit/` dizinine kopyalayın.
+3. `data/` dizinindeki içerikleri `~/.config/obs-studio/plugins/flood-tuber/data/` dizinine kopyalayın.
+4. OBS Studio'yu yeniden başlatın.
 
 ## Kullanım
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -49,6 +49,34 @@ Flood Tuber'ın en son sürümünü şuradan indirebilirsiniz:
 4.  `data/obs-plugins` klasörü içindeki `flood-tuber` klasörünü OBS veri dizinine kopyalayın (genellikle `C:\Program Files\obs-studio\data\obs-plugins\flood-tuber`).
 5.  OBS Studio'yu yeniden başlatın.
 
+### macOS
+
+#### Kaynak koddan derleme
+
+**Gereksinimler:** OBS Studio (Homebrew), CMake, Git ve Xcode Command Line Tools.
+
+```bash
+# Bağımlılıkları yükleyin
+brew install cmake obs-studio
+```
+
+**Derleme ve kurulum:**
+
+```bash
+git clone https://github.com/justflood/flood-tuber.git
+cd flood-tuber
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+sudo cmake --install build --prefix /usr/local
+```
+
+#### Manuel kurulum (taşınabilir)
+
+1. Yukarıdaki gibi derleyin.
+2. `build/flood-tuber.so` dosyasını `~/Library/Application Support/obs-studio/plugins/flood-tuber/bin/` dizinine kopyalayın.
+3. `data/` dizinindeki içerikleri `~/Library/Application Support/obs-studio/plugins/flood-tuber/data/` dizinine kopyalayın.
+4. OBS Studio'yu yeniden başlatın.
+
 ### Linux
 
 #### Kaynak koddan derleme

--- a/flood-tuber-props.cpp
+++ b/flood-tuber-props.cpp
@@ -9,22 +9,26 @@
 #include <windows.h>
 #include <shellapi.h>
 #else
-#include <stdlib.h>
-#include <stdio.h>
+#include <unistd.h>
 #endif
 
 static void open_in_system(const char *path_or_url)
 {
+	if (!path_or_url || !*path_or_url)
+		return;
+
 #ifdef _WIN32
 	ShellExecuteA(NULL, "open", path_or_url, NULL, NULL, SW_SHOWNORMAL);
 #elif __APPLE__
-	char cmd[2048];
-	snprintf(cmd, sizeof(cmd), "open '%s' &", path_or_url);
-	system(cmd);
+	if (fork() == 0) {
+		execlp("open", "open", path_or_url, (char *)NULL);
+		_exit(1);
+	}
 #else
-	char cmd[2048];
-	snprintf(cmd, sizeof(cmd), "xdg-open '%s' &", path_or_url);
-	system(cmd);
+	if (fork() == 0) {
+		execlp("xdg-open", "xdg-open", path_or_url, (char *)NULL);
+		_exit(1);
+	}
 #endif
 }
 

--- a/flood-tuber-props.cpp
+++ b/flood-tuber-props.cpp
@@ -8,7 +8,25 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <shellapi.h>
+#else
+#include <stdlib.h>
+#include <stdio.h>
 #endif
+
+static void open_in_system(const char *path_or_url)
+{
+#ifdef _WIN32
+	ShellExecuteA(NULL, "open", path_or_url, NULL, NULL, SW_SHOWNORMAL);
+#elif __APPLE__
+	char cmd[2048];
+	snprintf(cmd, sizeof(cmd), "open '%s' &", path_or_url);
+	system(cmd);
+#else
+	char cmd[2048];
+	snprintf(cmd, sizeof(cmd), "xdg-open '%s' &", path_or_url);
+	system(cmd);
+#endif
+}
 
 // Returns the custom avatars folder path from source settings.
 // Returns NULL if not set. Do NOT free the returned pointer.
@@ -461,20 +479,15 @@ static bool open_library_folder(obs_properties_t *props, obs_property_t *p, void
 	obs_data_t *settings = obs_source_get_settings(tuber->source);
 	if (!settings) return false;
 
-	const char *custom = get_custom_dir(settings);
+		const char *custom = get_custom_dir(settings);
 	if (custom) {
 		BLOG(LOG_INFO, "open_folder: opening %s", custom);
-#ifdef _WIN32
-		ShellExecuteA(NULL, "open", custom, NULL, NULL, SW_SHOWDEFAULT);
-#endif
+		open_in_system(custom);
 	} else {
-		// No custom folder set — open built-in avatars dir
 		char *data_dir = obs_module_file("avatars");
 		if (data_dir) {
 			BLOG(LOG_INFO, "open_folder: no custom dir, opening built-in: %s", data_dir);
-#ifdef _WIN32
-			ShellExecuteA(NULL, "open", data_dir, NULL, NULL, SW_SHOWDEFAULT);
-#endif
+			open_in_system(data_dir);
 			bfree(data_dir);
 		}
 	}
@@ -517,10 +530,7 @@ static void add_file_prop(obs_properties_t *props, const char *name, const char 
 static bool open_github_page(obs_properties_t *props, obs_property_t *p, void *data)
 {
 	(void)props; (void)p; (void)data;
-#ifdef _WIN32
-	ShellExecuteA(NULL, "open", "https://github.com/justflood/flood-tuber",
-	              NULL, NULL, SW_SHOWNORMAL);
-#endif
+	open_in_system("https://github.com/justflood/flood-tuber");
 	return false;
 }
 
@@ -528,10 +538,7 @@ static bool open_github_page(obs_properties_t *props, obs_property_t *p, void *d
 static bool open_website_page(obs_properties_t *props, obs_property_t *p, void *data)
 {
 	(void)props; (void)p; (void)data;
-#ifdef _WIN32
-	ShellExecuteA(NULL, "open", "https://floodtechlab.com/floodtuber/",
-	              NULL, NULL, SW_SHOWNORMAL);
-#endif
+	open_in_system("https://floodtechlab.com/floodtuber/");
 	return false;
 }
 

--- a/flood-tuber.cpp
+++ b/flood-tuber.cpp
@@ -2,6 +2,11 @@
 #include "flood-tuber-props.h"
 #include <util/dstr.h>
 #include <math.h>
+#include <strings.h>
+
+#ifndef _WIN32
+#define _strcmpi strcasecmp
+#endif
 
 
 // Validate file headers to prevent crashes (e.g. renamed .txt files)

--- a/flood-tuber.cpp
+++ b/flood-tuber.cpp
@@ -2,9 +2,9 @@
 #include "flood-tuber-props.h"
 #include <util/dstr.h>
 #include <math.h>
-#include <strings.h>
 
 #ifndef _WIN32
+#include <strings.h>
 #define _strcmpi strcasecmp
 #endif
 


### PR DESCRIPTION
## Summary

This PR adds Linux and macOS build/runtime support to Flood Tuber while maintaining full Windows compatibility.

## Changes

### Cross-platform file/URL opener (`flood-tuber-props.cpp`)
- Replaced Windows-only `ShellExecuteA()` calls with a cross-platform `open_in_system()` helper
- Uses `ShellExecuteA` on Windows, `fork()`+`execlp(open)` on macOS, `fork()`+`execlp(xdg-open)` on Linux
- No shell injection risk — uses `exec` directly, no `system()` calls
- Includes NULL/empty input guard

### POSIX string compatibility (`flood-tuber.cpp`)
- `_strcmpi` is Windows-only; added `#define _strcmpi strcasecmp` for non-Windows platforms
- `#include <strings.h>` is guarded by `#ifndef _WIN32` to avoid MSVC breakage

### CMake build system (`CMakeLists.txt`)
- Added `find_package(libobs CONFIG REQUIRED)` for proper OBS SDK discovery
- Uses `if(COMMAND set_target_properties_obs)` — delegates to OBS cmake helpers when available, falls back to manual properties on systems without them (e.g., Arch Linux)
- Added `install()` rules so `make install` / `cmake --install` works on all platforms
- Platform-agnostic fallback destinations for `OBS_PLUGIN_DESTINATION` and `OBS_DATA_DESTINATION`

### Documentation
- Added macOS build/install instructions (Homebrew) to `README.md` and `README.tr.md`
- Added Linux build/install instructions to `README.md` and `README.tr.md`
- Covers both system-wide (`cmake --install`) and user-local plugin folder installation

### Gitignore
- Added `*.so`, `*.so.*`, `*.dylib` for Linux/macOS shared library artifacts

## Verified
- Successfully builds on Linux (CachyOS / Arch-based, GCC 16)
- Produces working `flood-tuber.so` with all 7 avatar packs